### PR TITLE
Fix unidiomatic-typecheck to handle both sides of comparison

### DIFF
--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -332,22 +332,28 @@ class ComparisonChecker(_BasicChecker):
         operator: str,
         right: nodes.NodeNG,
     ) -> None:
-        """Check for expressions like type(x) == Y."""
+        """Check for expressions like type(x) == Y or Y == type(x)."""
+        # Check if left is type(x)
         left_func = utils.safe_infer(left.func)
-        if not (
+        left_is_type = (
             isinstance(left_func, nodes.ClassDef) and left_func.qname() == TYPE_QNAME
-        ):
-            return
+        )
 
-        if operator in {"is", "is not"} and _is_one_arg_pos_call(right):
+        # Check if right is type(x)
+        right_func = None
+        if _is_one_arg_pos_call(right):
             right_func = utils.safe_infer(right.func)
-            if (
-                isinstance(right_func, nodes.ClassDef)
-                and right_func.qname() == TYPE_QNAME
-            ):
-                # type(x) == type(a)
-                right_arg = utils.safe_infer(right.args[0])
-                if not isinstance(right_arg, LITERAL_NODE_TYPES):
-                    # not e.g. type(x) == type([])
-                    return
-        self.add_message("unidiomatic-typecheck", node=node)
+        right_is_type = (
+            isinstance(right_func, nodes.ClassDef) and right_func.qname() == TYPE_QNAME
+        )
+
+        # Handle type(x) == type(a) special case
+        if operator in {"is", "is not"} and left_is_type and right_is_type:
+            right_arg = utils.safe_infer(right.args[0])
+            if not isinstance(right_arg, LITERAL_NODE_TYPES):
+                # not e.g. type(x) == type([])
+                return
+
+        # If either side is a type() call, emit the warning
+        if left_is_type or right_is_type:
+            self.add_message("unidiomatic-typecheck", node=node)

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -72,6 +72,59 @@ class TestTypeChecker(CheckerTestCase):
             self.checker.visit_attribute(node)
 
 
+class TestTypeComparisonChecker(CheckerTestCase):
+    """Tests for pylint.checkers.typecheck comparison checks."""
+
+    CHECKER_CLASS = typecheck.TypeChecker
+
+    def test_unidiomatic_typecheck_left_side(self) -> None:
+        node = astroid.extract_node(
+            """
+        type(1) == int  #@
+        """
+        )
+        message = MessageTest(
+            "unidiomatic-typecheck",
+            node=node,
+            args=None,
+            confidence=UNDEFINED,
+            line=2,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=14,
+        )
+        with self.assertAddsMessages(message):
+            self.checker.visit_compare(node)
+
+    def test_unidiomatic_typecheck_right_side(self) -> None:
+        node = astroid.extract_node(
+            """
+        int == type(1)  #@
+        """
+        )
+        message = MessageTest(
+            "unidiomatic-typecheck",
+            node=node,
+            args=None,
+            confidence=UNDEFINED,
+            line=2,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=14,
+        )
+        with self.assertAddsMessages(message):
+            self.checker.visit_compare(node)
+
+    def test_unidiomatic_typecheck_not_triggered(self) -> None:
+        node = astroid.extract_node(
+            """
+        isinstance(1, int)  #@
+        """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+
 class TestTypeCheckerOnDecorators(CheckerTestCase):
     """Tests for pylint.checkers.typecheck on decorated functions."""
 


### PR DESCRIPTION
This PR fixes issue #3 by making the unidiomatic-typecheck checker handle type() comparisons on both sides of the comparison operator.